### PR TITLE
First delete the row from the database before processing

### DIFF
--- a/lib/Command/PreGenerate.php
+++ b/lib/Command/PreGenerate.php
@@ -110,13 +110,16 @@ class PreGenerate extends Command {
 			}
 
 			foreach ($rows as $row) {
-				$this->processRow($row);
-
-				// Delete row
+				/*
+				 * First delete the row so that if preview generation fails for some reason
+				 * the next run can just continue
+				 */
 				$qb = $this->connection->getQueryBuilder();
 				$qb->delete('preview_generation')
 					->where($qb->expr()->eq('id', $qb->createNamedParameter($row['id'])));
 				$qb->execute();
+
+				$this->processRow($row);
 			}
 		}
 	}


### PR DESCRIPTION
This makes sure that we can continue at the next file in the next
iteration. Else we keep failing on the same file over and over again.

It is not ideal and we should do a better job in the server. But a quick
enough hack for now.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>