### PR TITLE
Add check for already running command

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -20,4 +20,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-$app = new \OCA\PreviewGenerator\AppInfo\Application('PreviewGenerator');
+$app = new \OCA\PreviewGenerator\AppInfo\Application('previewgenerator');


### PR DESCRIPTION
At the start and after each processed file we now write a value to the
appconfig. This value is cleared on a successfull exit. If another run
is started before the current run is finished we check if the latest
activity is >30 minutes ago. If so we assume the process is dead.

Fixes #2 