### PR TITLE
Add timestamps to verbose process messages

### DIFF
--- a/lib/Command/Generate.php
+++ b/lib/Command/Generate.php
@@ -167,7 +167,7 @@ class Generate extends Command {
 	 * @param Folder $folder
 	 */
 	private function parseFolder(Folder $folder) {
-		$this->output->writeln('Scanning folder ' . $folder->getPath());
+		$this->output->writeln((extension_loaded('date') ? date('Y-m-d H:i:s ') : '') . 'Scanning folder ' . $folder->getPath());
 
 		$nodes = $folder->getDirectoryListing();
 
@@ -186,7 +186,7 @@ class Generate extends Command {
 	private function parseFile(File $file) {
 		if ($this->previewGenerator->isMimeSupported($file->getMimeType())) {
 			if ($this->output->getVerbosity() > OutputInterface::VERBOSITY_VERBOSE) {
-				$this->output->writeln('Generating previews for ' . $file->getPath());
+				$this->output->writeln((extension_loaded('date') ? date('Y-m-d H:i:s ') : '') . 'Generating previews for ' . $file->getPath());
 			}
 
 			try {

--- a/lib/Command/PreGenerate.php
+++ b/lib/Command/PreGenerate.php
@@ -205,7 +205,7 @@ class PreGenerate extends Command {
 	private function processFile(File $file) {
 		if ($this->previewGenerator->isMimeSupported($file->getMimeType())) {
 			if ($this->output->getVerbosity() > OutputInterface::VERBOSITY_VERBOSE) {
-				$this->output->writeln('Generating previews for ' . $file->getPath());
+				$this->output->writeln((extension_loaded('date') ? date('Y-m-d H:i:s ') : '') . 'Generating previews for ' . $file->getPath());
 			}
 
 			try {
@@ -235,7 +235,7 @@ class PreGenerate extends Command {
 
 	private function processFolder(Folder $folder) {
 		if ($this->output->getVerbosity() > OutputInterface::VERBOSITY_VERBOSE) {
-			$this->output->writeln('Generating previews for folder ' . $folder->getPath());
+			$this->output->writeln((extension_loaded('date') ? date('Y-m-d H:i:s ') : '') . 'Generating previews for folder ' . $folder->getPath());
 		}
 
 		$nodes = $folder->getDirectoryListing();


### PR DESCRIPTION
- Makes it easier to find files for related errors e.g. on nextcloud log.
- Derive duration for generating previews, performance testing etc.
- MySQL DATETIME format is used to have some kind of standard.
- Maybe there is an easier way to provide a timestamp for every php execution message, perhaps even in local time and date format?