### PR TITLE
Avoid folder processing on pre-generate

### DIFF
--- a/lib/Command/PreGenerate.php
+++ b/lib/Command/PreGenerate.php
@@ -25,7 +25,6 @@ namespace OCA\PreviewGenerator\Command;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Encryption\IManager;
 use OCP\Files\File;
-use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\IConfig;
@@ -197,8 +196,6 @@ class PreGenerate extends Command {
 		$node = $nodes[0];
 		if ($node instanceof File) {
 			$this->processFile($node);
-		} else {
-			$this->processFolder($node);
 		}
 	}
 
@@ -231,22 +228,6 @@ class PreGenerate extends Command {
 		}
 
 		$this->updateLastActivity();
-	}
-
-	private function processFolder(Folder $folder) {
-		if ($this->output->getVerbosity() > OutputInterface::VERBOSITY_VERBOSE) {
-			$this->output->writeln('Generating previews for folder ' . $folder->getPath());
-		}
-
-		$nodes = $folder->getDirectoryListing();
-
-		foreach ($nodes as $node) {
-			if ($node instanceof File) {
-				$this->processFile($node);
-			} else if ($node instanceof Folder) {
-				$this->processFolder($node);
-			}
-		}
 	}
 
 	private function calculateSizes() {

--- a/lib/Watcher.php
+++ b/lib/Watcher.php
@@ -22,6 +22,7 @@
  */
 namespace OCA\PreviewGenerator;
 
+use OCP\Files\Folder;
 use OCP\Files\Node;
 use OCP\IDBConnection;
 use OCP\IUserManager;
@@ -56,7 +57,7 @@ class Watcher {
 		$absPath = ltrim($node->getPath(), '/');
 		$owner = explode('/', $absPath)[0];
 
-		if (!$this->userManager->userExists($owner)) {
+		if (!$this->userManager->userExists($owner) || $node instanceof Folder) {
 			return;
 		}
 


### PR DESCRIPTION
This **in theory** fixes #62.

When you upload a file (or a folder) the folder/s and the files are added to the db, so if I'm not missing something there is no need to process folders.

Furthermore related with #62, on my end I could find that the duplicate folder was the root user folder ex: `/data/exampleuser/` (I can't really say why the root folder was passed to the `postWrite()` method on [Watcher.php](https://github.com/rullzer/previewgenerator/blob/master/lib/Watcher.php)) so as you can imagine the `processFolder()` method tried to scan the entire user folder multiple times.