### PR TITLE
Add timestamp to command outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 ### Added
+- Show timestamp in occ commands [#88](https://github.com/rullzer/previewgenerator/pull/88)
 
 ## 1.0.8 - 2017-12-21
 

--- a/lib/Command/Generate.php
+++ b/lib/Command/Generate.php
@@ -105,6 +105,9 @@ class Generate extends Command {
 			return 1;
 		}
 
+		// Set timestamp output
+		$formatter = new TimestampFormatter($this->config, $output->getFormatter());
+		$output->setFormatter($formatter);
 		$this->output = $output;
 
 		$userId = $input->getArgument('user_id');

--- a/lib/Command/PreGenerate.php
+++ b/lib/Command/PreGenerate.php
@@ -131,6 +131,10 @@ class PreGenerate extends Command {
 		}
 
 		$this->updateLastActivity();
+
+		// Set timestamp output
+		$formatter = new TimestampFormatter($this->config, $output->getFormatter());
+		$output->setFormatter($formatter);
 		$this->output = $output;
 
 		$this->sizes = SizeHelper::calculateSizes($this->config);

--- a/lib/Command/TimestampFormatter.php
+++ b/lib/Command/TimestampFormatter.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\PreviewGenerator\Command;
+
+use OCP\IConfig;
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+use Symfony\Component\Console\Formatter\OutputFormatterStyleInterface;
+
+/**
+ * TODO: This was taken from the server. At some point we should have it in OCP
+ * and then just use that
+ *
+ * Class TimestampFormatter
+ *
+ * @package OCA\PreviewGenerator\Command
+ */
+class TimestampFormatter implements OutputFormatterInterface {
+	/** @var IConfig */
+	protected $config;
+
+	/** @var OutputFormatterInterface */
+	protected $formatter;
+
+	/**
+	 * @param IConfig $config
+	 * @param OutputFormatterInterface $formatter
+	 */
+	public function __construct(IConfig $config, OutputFormatterInterface $formatter) {
+		$this->config = $config;
+		$this->formatter = $formatter;
+	}
+
+	/**
+	 * Sets the decorated flag.
+	 *
+	 * @param bool $decorated Whether to decorate the messages or not
+	 */
+	public function setDecorated($decorated) {
+		$this->formatter->setDecorated($decorated);
+	}
+
+	/**
+	 * Gets the decorated flag.
+	 *
+	 * @return bool true if the output will decorate messages, false otherwise
+	 */
+	public function isDecorated() {
+		return $this->formatter->isDecorated();
+	}
+
+	/**
+	 * Sets a new style.
+	 *
+	 * @param string $name The style name
+	 * @param OutputFormatterStyleInterface $style The style instance
+	 */
+	public function setStyle($name, OutputFormatterStyleInterface $style) {
+		$this->formatter->setStyle($name, $style);
+	}
+
+	/**
+	 * Checks if output formatter has style with specified name.
+	 *
+	 * @param string $name
+	 * @return bool
+	 */
+	public function hasStyle($name) {
+		return $this->formatter->hasStyle($name);
+	}
+
+	/**
+	 * Gets style options from style with specified name.
+	 *
+	 * @param string $name
+	 * @return OutputFormatterStyleInterface
+	 * @throws \InvalidArgumentException When style isn't defined
+	 */
+	public function getStyle($name) {
+		return $this->formatter->getStyle($name);
+	}
+
+	/**
+	 * Formats a message according to the given styles.
+	 *
+	 * @param string $message The message to style
+	 * @return string The styled message, prepended with a timestamp using the
+	 * log timezone and dateformat, e.g. "2015-06-23T17:24:37+02:00"
+	 */
+	public function format($message) {
+
+		$timeZone = $this->config->getSystemValue('logtimezone', 'UTC');
+		$timeZone = $timeZone !== null ? new \DateTimeZone($timeZone) : null;
+
+		$time = new \DateTime('now', $timeZone);
+		$timestampInfo = $time->format($this->config->getSystemValue('logdateformat', \DateTime::ATOM));
+
+		return $timestampInfo . ' ' . $this->formatter->format($message);
+	}
+}


### PR DESCRIPTION
As suggested by @MichaIng

Took the TimestampFormatter from OC\Console\TimestampFormatter since
there is no OCP variant yet.

Just prepends the timestamp verbose

Replaces #66 
Should be more maintainable especially if we get the formatter into OCP :)
