### PR TITLE
Generate: skip folder if .nomedia file present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Show timestamp in occ commands [#88](https://github.com/rullzer/previewgenerator/pull/88)
 - Add Composer Classmap for file (NC13) [#90](https://github.com/rullzer/previewgenerator/pull/90)
+- Respect .nomedia [#92](https://github.com/rullzer/previewgenerator/pull/92)
 
 ## 1.0.8 - 2017-12-21
 

--- a/lib/Command/Generate.php
+++ b/lib/Command/Generate.php
@@ -142,6 +142,12 @@ class Generate extends Command {
 	 * @param Folder $folder
 	 */
 	private function parseFolder(Folder $folder) {
+		// Respect the '.nomedia' file. If present don't traverse the folder
+		if ($folder->nodeExists('.nomedia')) {
+			$this->output->writeln('Skipping folder ' . $folder->getPath());
+			return;
+		}
+
 		$this->output->writeln('Scanning folder ' . $folder->getPath());
 
 		$nodes = $folder->getDirectoryListing();


### PR DESCRIPTION
Properly respect the .nomedia file. This means we won't traverse into
the folder if that is present.

Replaces #61 